### PR TITLE
Move stubs to better surface the README and make README better and publish to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+dist/
+typings/
+poetry.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.languageServer": "Pylance",
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportMissingModuleSource": "none"
+    },
+    "python.analysis.typeshedPaths": [
+        "./typings/",
+    ],
+    "python.analysis.extraPaths": [
+        "./stubs/",
+        "./wakeup/",
+    ],
+}

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,34 @@
+# Publishing
+
+Publishing is done using poetry, so it should be installed
+
+reqs:
+ - poetry installed and on path
+   `pip install -r requirements.txt`
+ - poetry api key stored in systems secure store or in environment variable `PYPI_API_KEY`
+
+## One time setup ( per host / environment)
+### PYPI test
+   - add repository to poetry config
+      `poetry config repositories.test-pypi https://test.pypi.org/legacy/`
+
+   - get token from https://test.pypi.org/manage/account/token/
+   - store token using `poetry config pypi-token.test-pypi  pypi-YYYYYYYY`
+   Note: 'test-pypi' is the name of the repository
+
+### PYPI Production
+   - get token from https://pypi.org/manage/account/token/
+   - store token using `poetry config pypi-token.pypi pypi-XXXXXXXX`
+
+
+## Bump version
+
+   `poetry version prerelease`
+   `poetry version patch`
+
+## Poetry Publish
+   To test
+   - `poetry publish -r test-pypi`
+
+   To PyPi
+   - `poetry publish --build`

--- a/README.md
+++ b/README.md
@@ -6,26 +6,11 @@ Type stubs include details about the constants, functions, classes and methods a
 
 # VSCode Setup
 
-If you're installing these stubs into Visual Studio Code you'll first need to clone this repository onto your computer, or [download the .zip file from the latest release](https://github.com/pimoroni/pimoroni-pico-stubs/releases/latest) or alternatively [find the release that matches the version of Pimoroni Pico MicroPython you're using.](https://github.com/pimoroni/pimoroni-pico-stubs/releases)
-
-To clone the repository, assuming you have git installed:
-
-```
-git clone https://github.com/pimoroni/pimoroni-pico-stubs
-```
-
-Make a note of the download directory for later:
-
-```
-cd pimoroni-pico-stubs
-pwd
-```
-
 ### Required Extensions
 
 You must install the VSCode Python extension and additionally Pylance to support type hints.
 
-To install extensions, press Ctrl+Shift+P or Cmd+Shift+P and in the pop-up box type "Extensions" and select "Extensions: Install Extensions."
+To install extensions, press Ctrl+Shift+P or Cmd+Shift+P and in the pop-up box type "Extensions" and select "Extensions: Install Extensions".
 
 A search box should open on the left-hand side of your editor, find and install the following:
 
@@ -36,46 +21,30 @@ A search box should open on the left-hand side of your editor, find and install 
 
 To open VSCode settings press Ctrl+Shift+P or Cmd+Shift+P and in the pop-up box type "Settings" and choose "Preferences: Open Workspace Settings (JSON)".
 
-If the file is empty you can go right ahead and add the lines below: 
+If the file is empty you can go right ahead and add the lines below:
 
 ```json
 {
     "python.languageServer": "Pylance",
-    "python.analysis.extraPaths": [
-        <site-packages>,
-        <pimoroni-pico-stubs>/stubs
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportMissingModuleSource": "none"
+    },
+    "python.analysis.typeshedPaths": [
+        "./typings/",
     ],
 }
+
 ```
-
-Replace `<site-packages>` with the output of the following command:
-
-```bash
-python3 -m site --user-site
-```
-
-`<pimoroni-pico-stubs>` is the download location of this repo, which you made a note of earlier.
 
 ### MicroPython stubs
 
-To get MicroPython type hints you'll need to install the following package:
+To get MicroPython type hints you'll need to install the following package into the `./typings` directory of your project.
 
-#### pico
+If the terminal is not open press Ctrl+Shift+P or Cmd+Shift+P and in the pop-up box type "Terminal" and select "Terminal: Create New Terminal (In Active Workspace)".
 
-```
-pip install micropython-rp2-pico-stubs
-```
+Finally in the terminal run the following command:
 
-#### pico-w
-
-```
-pip install micropython-rp2-pico-w-stubs
-```
-
-### Standard libaries ###
-
-MicroPython and Python standard libraries sometimes differ and by default the type hints will use the standard library over micropython. In order to get MicroPython type hints instead import the `u` prefixed library e.g:
-
-```python
-import utime as time
+```bash
+pip install pimoroni-pico-stubs --target ./typings --no-user
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.poetry]
+name = "pimoroni-pico-stubs"
+version = "1.20.3"
+description = "MicroPython Stubs for Pimoroni MicroPython libraries for RP2040-based boards"
+license = "MIT"
+authors = []
+readme = "README.md"
+homepage = "https://github.com/pimoroni/pimoroni-pico-stubs"
+repository = "https://github.com/pimoroni/pimoroni-pico-stubs"
+
+packages = [
+    { "include" = "**/*.pyi", "from" = "stubs/"},
+    { "include" = "wakeup/**/*.pyi"},
+]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+micropython-rp2-rpi_pico_w-stubs = ">=1.20.0"
+
+[build-system]
+requires = [
+    "poetry-core>=1.0.0",
+]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Expanding on #9 I have been able to simplify the install instructions by publishing it to PYPI.

These changes eliminate a couple of steps and also no longer requires the user to make changes based on where they want to install things. It also depends on the pico_w stubs so those will come bundled

This also fixes:
* Importing of non-u prefixed packages, as u-prefixed packages will be discontinued in a future version of Micropython. 
* Importing of Micropython stdlib/builtins instead of Python stdlib/builtins

If you want to test them yourself I have made a test release which can be installed by following the README and running the following:
```bash
pip install north101-pimoroni-pico-stubs --target ./typings --no-user
```